### PR TITLE
Add FC 26 club exporter prototype

### DIFF
--- a/public/tools/fc26-club-exporter.user.js
+++ b/public/tools/fc26-club-exporter.user.js
@@ -1,0 +1,328 @@
+// ==UserScript==
+// @name        FC 26 Club Exporter (Prototype)
+// @namespace   https://amerkovacevic.com/
+// @version     0.1.0
+// @description Prototype helper that watches the EA FC 26 web app for club data and writes a solver-friendly roster string to localStorage.
+// @match       https://www.ea.com/*
+// @run-at      document-start
+// @grant       none
+// ==/UserScript==
+
+(function () {
+  const STORAGE_KEY = "fc26-sbc-import";
+  const overlayId = "fc26-sbc-export-overlay";
+  const roster = new Map();
+  let lastPersist = "";
+
+  const originalFetch = window.fetch;
+  window.fetch = async function patchedFetch(input, init) {
+    const response = await originalFetch.apply(this, arguments);
+    try {
+      const clone = response.clone();
+      processResponse(clone, resolveRequestUrl(input));
+    } catch (error) {
+      console.debug("FC26 exporter fetch interception failed", error);
+    }
+    return response;
+  };
+
+  const originalXhrSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.send = function patchedSend() {
+    this.addEventListener("load", function () {
+      try {
+        const contentType = this.getResponseHeader("content-type") || "";
+        if (!contentType.includes("application/json")) return;
+        const url = this.responseURL || "";
+        const text = this.responseText;
+        if (!text) return;
+        processPotentialJson(text, url);
+      } catch (error) {
+        console.debug("FC26 exporter XHR interception failed", error);
+      }
+    });
+    return originalXhrSend.apply(this, arguments);
+  };
+
+  function resolveRequestUrl(input) {
+    try {
+      if (typeof input === "string") {
+        return new URL(input, location.href).href;
+      }
+      if (input instanceof Request) {
+        return input.url;
+      }
+    } catch (error) {
+      console.debug("FC26 exporter failed to resolve URL", error);
+    }
+    return "";
+  }
+
+  async function processResponse(response, url) {
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) return;
+    const text = await response.text();
+    processPotentialJson(text, url || response.url || "");
+  }
+
+  function processPotentialJson(text, url) {
+    if (!shouldParseUrl(url)) return;
+    try {
+      const data = JSON.parse(text);
+      scanForPlayers(data);
+    } catch (error) {
+      console.debug("FC26 exporter failed to parse JSON", error);
+    }
+  }
+
+  function shouldParseUrl(url) {
+    if (!url) return false;
+    if (/\/ut\/game\/fifa/i.test(url)) return true;
+    if (/fc26/i.test(url) && /club|squad|pile|item/i.test(url)) return true;
+    return false;
+  }
+
+  function scanForPlayers(node) {
+    if (!node) return;
+    if (Array.isArray(node)) {
+      if (node.length && looksLikePlayer(node[0])) {
+        for (const item of node) {
+          ingestPlayer(item);
+        }
+        return;
+      }
+      for (const item of node) scanForPlayers(item);
+      return;
+    }
+    if (typeof node === "object") {
+      const values = Object.values(node);
+      if (values.some((value) => looksLikePlayer(value))) {
+        for (const value of values) {
+          if (Array.isArray(value)) {
+            for (const item of value) ingestPlayer(item);
+          } else if (typeof value === "object" && value) {
+            ingestPlayer(value);
+          }
+        }
+      } else {
+        for (const value of values) scanForPlayers(value);
+      }
+    }
+  }
+
+  function looksLikePlayer(candidate) {
+    if (!candidate) return false;
+    if (Array.isArray(candidate)) return candidate.some(looksLikePlayer);
+    if (typeof candidate !== "object") return false;
+    const rating = pickNumber(candidate, ["rating", "overallRating", "ovr", "totalRating", "statsRating"]);
+    const name = pickString(candidate, ["name", "commonName", "firstName", "lastName", "playerName"]);
+    const team = pickString(candidate, ["club", "team", "teamName", "clubName", "clubAbbr"]);
+    const league = pickString(candidate, ["league", "leagueName", "leagueFullName"]);
+    return Boolean(rating && name && (team || league));
+  }
+
+  function ingestPlayer(raw) {
+    if (!raw || typeof raw !== "object") return;
+    const id = pickString(raw, ["definitionId", "id", "itemId", "resourceId"]) || String(pickNumber(raw, ["definitionId", "id", "itemId", "resourceId"])) || undefined;
+    const rating = pickNumber(raw, ["rating", "overallRating", "ovr", "totalRating", "statsRating"]);
+    if (!rating) return;
+
+    const nameParts = [];
+    const first = pickString(raw, ["commonName", "firstName", "name"]);
+    const last = pickString(raw, ["lastName", "surname", "playerName"]);
+    if (first) nameParts.push(first);
+    if (last && !first?.includes(last)) nameParts.push(last);
+    let name = nameParts.join(" ").trim();
+    if (!name) {
+      name = pickString(raw, ["commonName", "name", "playerName", "fullName"]) || "";
+    }
+    if (!name) return;
+
+    const nation = pickString(raw, ["nationName", "nation", "country", "nationality", "nationAbbr"]) || "";
+    const league = pickString(raw, ["leagueName", "league", "leagueFullName", "leagueAbbr"]) || "";
+    const club = pickString(raw, ["teamName", "clubName", "club", "team", "clubAbbr", "teamAbbr"]) || "";
+
+    const positions = extractPositions(raw);
+
+    const normalized = normalizeRecord({
+      name,
+      rating,
+      nation,
+      league,
+      club,
+      positions,
+    });
+
+    if (!normalized) return;
+    const key = id || `${normalized.name}|${normalized.rating}|${normalized.club}`;
+    roster.set(key, normalized);
+    persistRoster();
+  }
+
+  function extractPositions(raw) {
+    const collected = new Set();
+    const direct = pickString(raw, ["preferredPosition", "bestPosition", "position", "role"]);
+    if (direct) collected.add(direct);
+
+    const arrays = [
+      raw.positions,
+      raw.positionInfo?.positions,
+      raw.playerPosition?.positions,
+      raw.secondaryPositions,
+    ].filter(Boolean);
+
+    for (const group of arrays) {
+      if (!Array.isArray(group)) continue;
+      for (const value of group) {
+        if (!value) continue;
+        if (typeof value === "string") {
+          collected.add(value);
+        } else if (typeof value === "object") {
+          const label = pickString(value, ["position", "abbr", "shortName"]);
+          if (label) collected.add(label);
+        }
+      }
+    }
+
+    return Array.from(collected);
+  }
+
+  function normalizeRecord(record) {
+    const rating = Number(record.rating);
+    if (!Number.isFinite(rating)) return null;
+    const name = titleCase(record.name);
+    if (!name) return null;
+    const league = record.league ? record.league.trim() : "";
+    const club = titleCase(record.club || "");
+    const nation = titleCase(record.nation || "");
+    const positions = (record.positions || [])
+      .map((pos) => String(pos).trim().toUpperCase())
+      .filter(Boolean);
+    return { name, rating: Math.round(rating), nation, league, club, positions };
+  }
+
+  function persistRoster() {
+    const lines = Array.from(roster.values()).map((player) => {
+      const parts = [player.name, player.rating, player.nation, player.league, player.club];
+      if (player.positions.length) {
+        parts.push(player.positions.join(" / "));
+      }
+      return parts.join(", ");
+    });
+    const payload = lines.join("\n");
+    if (payload === lastPersist) return;
+    lastPersist = payload;
+    try {
+      localStorage.setItem(STORAGE_KEY, payload);
+    } catch (error) {
+      console.warn("FC26 exporter failed to persist roster", error);
+    }
+  }
+
+  function pickNumber(source, keys) {
+    for (const key of keys) {
+      const value = source?.[key];
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+      if (typeof value === "string" && value.trim() && !Number.isNaN(Number(value))) {
+        return Number(value);
+      }
+    }
+    return undefined;
+  }
+
+  function pickString(source, keys) {
+    for (const key of keys) {
+      const value = source?.[key];
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+    return undefined;
+  }
+
+  function titleCase(value) {
+    return value
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(" ");
+  }
+
+  function injectOverlay() {
+    if (document.getElementById(overlayId)) return;
+    const container = document.createElement("div");
+    container.id = overlayId;
+    container.style.position = "fixed";
+    container.style.bottom = "16px";
+    container.style.right = "16px";
+    container.style.zIndex = "999999";
+    container.style.display = "flex";
+    container.style.flexDirection = "column";
+    container.style.gap = "8px";
+    container.style.fontFamily = "Inter, system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
+
+    const button = document.createElement("button");
+    button.textContent = "Copy club to SBC solver";
+    button.style.padding = "10px 14px";
+    button.style.borderRadius = "9999px";
+    button.style.border = "none";
+    button.style.background = "#2563eb";
+    button.style.color = "white";
+    button.style.fontSize = "13px";
+    button.style.cursor = "pointer";
+    button.style.boxShadow = "0 10px 30px rgba(37, 99, 235, 0.35)";
+
+    const status = document.createElement("span");
+    status.style.background = "rgba(15, 23, 42, 0.85)";
+    status.style.color = "white";
+    status.style.padding = "6px 10px";
+    status.style.borderRadius = "9999px";
+    status.style.fontSize = "12px";
+    status.style.display = "none";
+
+    button.addEventListener("click", async () => {
+      const payload = localStorage.getItem(STORAGE_KEY) || "";
+      try {
+        await navigator.clipboard.writeText(payload);
+        showStatus("Copied club export to clipboard", status);
+      } catch (error) {
+        console.warn("FC26 exporter failed to copy", error);
+        showStatus("Copy failed – check console", status);
+      }
+    });
+
+    container.appendChild(button);
+    container.appendChild(status);
+    document.body.appendChild(container);
+  }
+
+  function showStatus(message, node) {
+    node.textContent = message;
+    node.style.display = "inline-flex";
+    clearTimeout(node._hideTimeout);
+    node._hideTimeout = setTimeout(() => {
+      node.style.display = "none";
+    }, 2500);
+  }
+
+  function exposeApi() {
+    window.fc26ClubExporter = {
+      getRoster() {
+        return localStorage.getItem(STORAGE_KEY) || "";
+      },
+      getPlayers() {
+        return Array.from(roster.values());
+      },
+      copyToClipboard() {
+        const payload = localStorage.getItem(STORAGE_KEY) || "";
+        return navigator.clipboard.writeText(payload);
+      },
+      clear() {
+        roster.clear();
+        localStorage.removeItem(STORAGE_KEY);
+      },
+    };
+  }
+
+  const observer = new MutationObserver(() => injectOverlay());
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+  injectOverlay();
+  exposeApi();
+})();

--- a/src/pages/sbc-solver/sbc-solver-page.tsx
+++ b/src/pages/sbc-solver/sbc-solver-page.tsx
@@ -31,6 +31,7 @@ import type { Attribute, Player, Requirement, SquadConfig } from "./types";
 
 const STORAGE_KEY = "fc26-sbc-state";
 const DEFAULT_CONFIG: SquadConfig = { squadSize: 11, minTeamRating: 84, minChemistry: 0 };
+const EXTERNAL_IMPORT_STORAGE_KEY = "fc26-sbc-import";
 
 const ATTRIBUTES: { value: Attribute; label: string }[] = [
   { value: "nation", label: "Nation" },
@@ -95,11 +96,33 @@ export default function SbcSolverPage() {
     setPlayerForm(emptyPlayerForm());
   };
 
-  const handleBulkImport = () => {
-    const parsed = parseBulkPlayers(bulkText);
+  const handleBulkImport = (raw?: string) => {
+    const source = typeof raw === "string" ? raw : bulkText;
+    const parsed = parseBulkPlayers(source);
     if (!parsed.length) return;
     setPlayers((prev) => [...prev, ...parsed]);
-    setBulkText("");
+    if (typeof raw !== "string") {
+      setBulkText("");
+    }
+  };
+
+  const handleBulkImportClick = () => {
+    handleBulkImport();
+  };
+
+  const handlePrototypeImport = () => {
+    try {
+      const raw = localStorage.getItem(EXTERNAL_IMPORT_STORAGE_KEY);
+      if (!raw) {
+        alert("No FC 26 web app export found yet. Run the club exporter prototype on the EA web app first.");
+        return;
+      }
+      handleBulkImport(raw);
+      alert("Imported players from FC 26 exporter prototype. You can clear the storage key once finished.");
+    } catch (error) {
+      console.error("Failed to load prototype import", error);
+      alert("Import failed. Check the console for details.");
+    }
   };
 
   const handleAddRequirement = () => {
@@ -381,8 +404,19 @@ export default function SbcSolverPage() {
                 className="min-h-[120px] w-full rounded-brand border border-border-light bg-white/90 px-3 py-2 text-sm text-brand-strong shadow-brand-sm focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand-accent/30 placeholder:text-brand-muted dark:border-border-dark dark:bg-surface-overlayDark dark:text-white dark:placeholder:text-brand-subtle"
               />
               <div className="flex flex-wrap gap-2">
-                <button type="button" onClick={handleBulkImport} className={buttonStyles({ variant: "secondary", size: "sm" })}>
+                <button
+                  type="button"
+                  onClick={handleBulkImportClick}
+                  className={buttonStyles({ variant: "secondary", size: "sm" })}
+                >
                   <ClipboardCopy className="h-4 w-4" aria-hidden /> Parse lines
+                </button>
+                <button
+                  type="button"
+                  onClick={handlePrototypeImport}
+                  className={buttonStyles({ variant: "secondary", size: "sm", className: "border-dashed" })}
+                >
+                  <Sparkles className="h-4 w-4" aria-hidden /> Prototype: read FC web app export
                 </button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- add a prototype userscript that scrapes FC 26 club data into solver-friendly CSV lines and exposes a copy helper
- extend the SBC solver bulk import controls with a one-click reader that ingests the exporter output from localStorage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccc79deba4832181f3de0cfbbd223d