### PR TITLE
Improve player detection in club exporter

### DIFF
--- a/public/tools/fc26-club-exporter.user.js
+++ b/public/tools/fc26-club-exporter.user.js
@@ -112,11 +112,63 @@
     if (!candidate) return false;
     if (Array.isArray(candidate)) return candidate.some(looksLikePlayer);
     if (typeof candidate !== "object") return false;
-    const rating = pickNumber(candidate, ["rating", "overallRating", "ovr", "totalRating", "statsRating"]);
-    const name = pickString(candidate, ["name", "commonName", "firstName", "lastName", "playerName"]);
-    const team = pickString(candidate, ["club", "team", "teamName", "clubName", "clubAbbr"]);
-    const league = pickString(candidate, ["league", "leagueName", "leagueFullName"]);
-    return Boolean(rating && name && (team || league));
+
+    const rating = pickNumber(candidate, [
+      "rating",
+      "overallRating",
+      "ovr",
+      "totalRating",
+      "statsRating",
+    ]);
+
+    const name =
+      pickString(candidate, [
+        "name",
+        "commonName",
+        "preferredName",
+        "firstName",
+        "lastName",
+        "playerName",
+      ]) || buildNameFromParts(candidate);
+
+    if (!rating || !name) return false;
+
+    if (
+      pickString(candidate, [
+        "club",
+        "team",
+        "teamName",
+        "clubName",
+        "clubAbbr",
+        "teamAbbr",
+      ])
+    ) {
+      return true;
+    }
+
+    if (
+      pickString(candidate, ["league", "leagueName", "leagueFullName", "leagueAbbr"]) ||
+      pickNumber(candidate, ["leagueId", "league", "leagueIdNumeric"])
+    ) {
+      return true;
+    }
+
+    if (pickNumber(candidate, ["definitionId", "id", "itemId", "resourceId", "assetId"])) {
+      return true;
+    }
+
+    if (pickString(candidate, ["preferredPosition", "bestPosition", "position", "role"])) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function buildNameFromParts(source) {
+    const first = pickString(source, ["commonName", "preferredName", "firstName", "name"]);
+    const last = pickString(source, ["lastName", "surname", "playerName"]);
+    if (first && last) return `${first} ${last}`;
+    return first || last || "";
   }
 
   function ingestPlayer(raw) {


### PR DESCRIPTION
## Summary
- broaden the heuristics used to detect player objects in intercepted responses
- accept additional naming fields and fallbacks so players without club text data are still captured

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccd76260208321b8a8478ab7fb20a3