### PR TITLE
Add FC 26 club import Chrome extension

### DIFF
--- a/public/tools/club-import-tool/background.js
+++ b/public/tools/club-import-tool/background.js
@@ -1,17 +1,24 @@
-// Optional example: add a context menu that logs the page title
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
-    id: 'log-title',
-    title: 'Log page title to console',
-    contexts: ['page']
+    id: "fc26-copy-roster",
+    title: "Copy FC 26 club export",
+    contexts: ["page"],
+    documentUrlPatterns: ["https://ea.com/*", "https://*.ea.com/*"],
   });
 });
 
-chrome.contextMenus.onClicked.addListener(async (info, tab) => {
-  if (info.menuItemId === 'log-title' && tab.id) {
-    await chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      func: () => console.log('Page title is:', document.title)
-    });
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId !== "fc26-copy-roster" || !tab?.id) {
+    return;
   }
+
+  chrome.tabs.sendMessage(tab.id, { type: "fc26:copyRoster" }, (response) => {
+    if (chrome.runtime.lastError) {
+      console.debug("FC26 copy context menu failed", chrome.runtime.lastError);
+      return;
+    }
+    if (!response?.success && response?.error) {
+      console.debug("FC26 copy context menu responded with error", response.error);
+    }
+  });
 });

--- a/public/tools/club-import-tool/content.js
+++ b/public/tools/club-import-tool/content.js
@@ -1,0 +1,523 @@
+(function () {
+  "use strict";
+
+  if (window.fc26ClubExporter?.__initialized) {
+    return;
+  }
+
+  const overlayId = "fc26-sbc-export-overlay";
+  const roster = new Map();
+  let latestExport = "";
+
+  const originalFetch = window.fetch;
+  window.fetch = async function patchedFetch(input, init) {
+    const response = await originalFetch.apply(this, arguments);
+    try {
+      const clone = response.clone();
+      processResponse(clone, resolveRequestUrl(input));
+    } catch (error) {
+      console.debug("FC26 importer fetch interception failed", error);
+    }
+    return response;
+  };
+
+  const originalXhrSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.send = function patchedSend() {
+    this.addEventListener("load", function () {
+      try {
+        const contentType = this.getResponseHeader("content-type") || "";
+        if (!contentType.includes("application/json")) return;
+        const url = this.responseURL || "";
+        const text = this.responseText;
+        if (!text) return;
+        processPotentialJson(text, url);
+      } catch (error) {
+        console.debug("FC26 importer XHR interception failed", error);
+      }
+    });
+    return originalXhrSend.apply(this, arguments);
+  };
+
+  function resolveRequestUrl(input) {
+    try {
+      if (typeof input === "string") {
+        return new URL(input, location.href).href;
+      }
+      if (input instanceof Request) {
+        return input.url;
+      }
+    } catch (error) {
+      console.debug("FC26 importer failed to resolve URL", error);
+    }
+    return "";
+  }
+
+  async function processResponse(response, url) {
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) return;
+    const text = await response.text();
+    processPotentialJson(text, url || response.url || "");
+  }
+
+  function processPotentialJson(text, url) {
+    if (!shouldParseUrl(url)) return;
+    try {
+      const data = JSON.parse(sanitizeJson(text));
+      scanForPlayers(data);
+    } catch (error) {
+      console.debug("FC26 importer failed to parse JSON", error);
+    }
+  }
+
+  function shouldParseUrl(url) {
+    if (!url) return false;
+    let target = url;
+    try {
+      target = new URL(url, location.href).href;
+    } catch (error) {
+      console.debug("FC26 importer failed to normalize URL", error);
+    }
+
+    if (/\/ut\/game\//i.test(target) && /club|squad|pile|item|player/i.test(target)) {
+      return true;
+    }
+
+    if (/fc/i.test(target) && /club|squad|pile|item|player/i.test(target)) {
+      return true;
+    }
+
+    if (/fifa/i.test(target) && /club|squad|pile|item|player/i.test(target)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function sanitizeJson(text) {
+    if (typeof text !== "string") return "";
+    const trimmed = text.trimStart();
+    const guards = [")]}',", ")]}'", "while(1);", "for(;;);"];
+    for (const guard of guards) {
+      if (trimmed.startsWith(guard)) {
+        return trimmed.slice(guard.length);
+      }
+    }
+    return trimmed;
+  }
+
+  function scanForPlayers(node) {
+    if (!node) return;
+    if (Array.isArray(node)) {
+      if (node.length && looksLikePlayer(node[0])) {
+        for (const item of node) {
+          ingestPlayer(item);
+        }
+        return;
+      }
+      for (const item of node) scanForPlayers(item);
+      return;
+    }
+    if (typeof node === "object") {
+      const values = Object.values(node);
+      if (values.some((value) => looksLikePlayer(value))) {
+        for (const value of values) {
+          if (Array.isArray(value)) {
+            for (const item of value) ingestPlayer(item);
+          } else if (typeof value === "object" && value) {
+            ingestPlayer(value);
+          }
+        }
+      } else {
+        for (const value of values) scanForPlayers(value);
+      }
+    }
+  }
+
+  function looksLikePlayer(candidate) {
+    if (!candidate) return false;
+    if (Array.isArray(candidate)) return candidate.some(looksLikePlayer);
+    if (typeof candidate !== "object") return false;
+
+    const rating = pickNumber(candidate, [
+      "rating",
+      "overallRating",
+      "ovr",
+      "totalRating",
+      "statsRating",
+    ]);
+
+    const name =
+      pickString(candidate, [
+        "name",
+        "commonName",
+        "preferredName",
+        "firstName",
+        "lastName",
+        "playerName",
+      ]) || buildNameFromParts(candidate);
+
+    if (!rating || !name) return false;
+
+    if (
+      pickString(candidate, [
+        "club",
+        "team",
+        "teamName",
+        "clubName",
+        "clubAbbr",
+        "teamAbbr",
+      ])
+    ) {
+      return true;
+    }
+
+    if (
+      pickString(candidate, ["league", "leagueName", "leagueFullName", "leagueAbbr"]) ||
+      pickNumber(candidate, ["leagueId", "league", "leagueIdNumeric"])
+    ) {
+      return true;
+    }
+
+    if (pickNumber(candidate, ["definitionId", "id", "itemId", "resourceId", "assetId"])) {
+      return true;
+    }
+
+    if (pickString(candidate, ["preferredPosition", "bestPosition", "position", "role"])) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function buildNameFromParts(source) {
+    const first = pickString(source, ["commonName", "preferredName", "firstName", "name"]);
+    const last = pickString(source, ["lastName", "surname", "playerName"]);
+    if (first && last) return `${first} ${last}`;
+    return first || last || "";
+  }
+
+  function ingestPlayer(raw) {
+    if (!raw || typeof raw !== "object") return;
+    const id =
+      pickString(raw, ["definitionId", "id", "itemId", "resourceId"]) ||
+      String(pickNumber(raw, ["definitionId", "id", "itemId", "resourceId"])) ||
+      undefined;
+    const rating = pickNumber(raw, ["rating", "overallRating", "ovr", "totalRating", "statsRating"]);
+    if (!rating) return;
+
+    const nameParts = [];
+    const first = pickString(raw, ["commonName", "firstName", "name"]);
+    const last = pickString(raw, ["lastName", "surname", "playerName"]);
+    if (first) nameParts.push(first);
+    if (last && !first?.includes(last)) nameParts.push(last);
+    let name = nameParts.join(" ").trim();
+    if (!name) {
+      name = pickString(raw, ["commonName", "name", "playerName", "fullName"]) || "";
+    }
+    if (!name) return;
+
+    const nation = pickString(raw, ["nationName", "nation", "country", "nationality", "nationAbbr"]) || "";
+    const league = pickString(raw, ["leagueName", "league", "leagueFullName", "leagueAbbr"]) || "";
+    const club = pickString(raw, ["teamName", "clubName", "club", "team", "clubAbbr", "teamAbbr"]) || "";
+
+    const positions = extractPositions(raw);
+
+    const normalized = normalizeRecord({
+      name,
+      rating,
+      nation,
+      league,
+      club,
+      positions,
+    });
+
+    if (!normalized) return;
+    const key = id || `${normalized.name}|${normalized.rating}|${normalized.club}`;
+    roster.set(key, normalized);
+    refreshExportBuffer();
+  }
+
+  function extractPositions(raw) {
+    const collected = new Set();
+    const direct = pickString(raw, ["preferredPosition", "bestPosition", "position", "role"]);
+    if (direct) collected.add(direct);
+
+    const arrays = [
+      raw.positions,
+      raw.positionInfo?.positions,
+      raw.playerPosition?.positions,
+      raw.secondaryPositions,
+    ].filter(Boolean);
+
+    for (const group of arrays) {
+      if (!Array.isArray(group)) continue;
+      for (const value of group) {
+        if (!value) continue;
+        if (typeof value === "string") {
+          collected.add(value);
+        } else if (typeof value === "object") {
+          const label = pickString(value, ["position", "abbr", "shortName"]);
+          if (label) collected.add(label);
+        }
+      }
+    }
+
+    return Array.from(collected);
+  }
+
+  function normalizeRecord(record) {
+    const rating = Number(record.rating);
+    if (!Number.isFinite(rating)) return null;
+    const name = titleCase(record.name);
+    if (!name) return null;
+    const league = record.league ? record.league.trim() : "";
+    const club = titleCase(record.club || "");
+    const nation = titleCase(record.nation || "");
+    const positions = (record.positions || [])
+      .map((pos) => String(pos).trim().toUpperCase())
+      .filter(Boolean);
+    return { name, rating: Math.round(rating), nation, league, club, positions };
+  }
+
+  function refreshExportBuffer() {
+    const lines = Array.from(roster.values()).map((player) => {
+      const parts = [player.name, player.rating, player.nation, player.league, player.club];
+      if (player.positions.length) {
+        parts.push(player.positions.join(" / "));
+      }
+      return parts.join(", ");
+    });
+    const payload = lines.join("\n");
+    latestExport = payload;
+  }
+
+  function pickNumber(source, keys) {
+    for (const key of keys) {
+      const value = source?.[key];
+      const extracted = extractNumber(value);
+      if (typeof extracted === "number") {
+        return extracted;
+      }
+    }
+    return undefined;
+  }
+
+  function extractNumber(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim() && !Number.isNaN(Number(value))) {
+      return Number(value);
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const extracted = extractNumber(item);
+        if (typeof extracted === "number") {
+          return extracted;
+        }
+      }
+    }
+    if (value && typeof value === "object") {
+      for (const key of ["value", "val", "defaultValue", "amount"]) {
+        const extracted = extractNumber(value[key]);
+        if (typeof extracted === "number") {
+          return extracted;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  function pickString(source, keys) {
+    for (const key of keys) {
+      const value = source?.[key];
+      const extracted = extractString(value);
+      if (typeof extracted === "string" && extracted.trim()) {
+        return extracted.trim();
+      }
+    }
+    return undefined;
+  }
+
+  function extractString(value) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const extracted = extractString(item);
+        if (typeof extracted === "string" && extracted.trim()) {
+          return extracted.trim();
+        }
+      }
+      return undefined;
+    }
+    if (value && typeof value === "object") {
+      for (const key of [
+        "value",
+        "val",
+        "name",
+        "fullName",
+        "default",
+        "defaultValue",
+        "longName",
+        "shortName",
+        "abbr",
+        "label",
+        "localized",
+        "localizedValue",
+        "text",
+      ]) {
+        const extracted = extractString(value[key]);
+        if (typeof extracted === "string" && extracted.trim()) {
+          return extracted.trim();
+        }
+      }
+    }
+    return undefined;
+  }
+
+  function titleCase(value) {
+    return value
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(" ");
+  }
+
+  function injectOverlay() {
+    if (document.getElementById(overlayId)) return;
+    const container = document.createElement("div");
+    container.id = overlayId;
+    container.style.position = "fixed";
+    container.style.bottom = "16px";
+    container.style.right = "16px";
+    container.style.zIndex = "999999";
+    container.style.display = "flex";
+    container.style.flexDirection = "column";
+    container.style.gap = "8px";
+    container.style.fontFamily = "Inter, system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
+
+    const button = document.createElement("button");
+    button.textContent = "Copy club export";
+    button.style.padding = "10px 14px";
+    button.style.borderRadius = "9999px";
+    button.style.border = "none";
+    button.style.background = "#2563eb";
+    button.style.color = "white";
+    button.style.fontSize = "13px";
+    button.style.cursor = "pointer";
+    button.style.boxShadow = "0 10px 30px rgba(37, 99, 235, 0.35)";
+
+    const status = document.createElement("span");
+    status.style.background = "rgba(15, 23, 42, 0.85)";
+    status.style.color = "white";
+    status.style.padding = "6px 10px";
+    status.style.borderRadius = "9999px";
+    status.style.fontSize = "12px";
+    status.style.display = "none";
+
+    button.addEventListener("click", async () => {
+      if (!latestExport) {
+        showStatus("No club data captured yet. Browse your club first.", status);
+        return;
+      }
+      if (!navigator.clipboard?.writeText) {
+        showStatus("Clipboard API unavailable in this browser", status);
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(latestExport);
+        showStatus("Copied club export to clipboard", status);
+      } catch (error) {
+        console.warn("FC26 importer failed to copy", error);
+        showStatus("Copy failed – check console", status);
+      }
+    });
+
+    container.appendChild(button);
+    container.appendChild(status);
+    document.body.appendChild(container);
+  }
+
+  function showStatus(message, node) {
+    node.textContent = message;
+    node.style.display = "inline-flex";
+    clearTimeout(node._hideTimeout);
+    node._hideTimeout = setTimeout(() => {
+      node.style.display = "none";
+    }, 2500);
+  }
+
+  function exposeApi() {
+    window.fc26ClubExporter = {
+      __initialized: true,
+      getRoster() {
+        return latestExport;
+      },
+      getPlayers() {
+        return Array.from(roster.values());
+      },
+      copyToClipboard() {
+        if (!latestExport) return Promise.resolve();
+        if (!navigator.clipboard?.writeText) {
+          return Promise.reject(new Error("Clipboard API unavailable"));
+        }
+        return navigator.clipboard.writeText(latestExport);
+      },
+      clear() {
+        roster.clear();
+        latestExport = "";
+      },
+    };
+  }
+
+  const observer = new MutationObserver(() => injectOverlay());
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+  injectOverlay();
+  exposeApi();
+
+  function handleMessage(message, sender, sendResponse) {
+    if (!message || typeof message.type !== "string") {
+      return;
+    }
+
+    if (message.type === "fc26:getSummary") {
+      sendResponse({
+        success: true,
+        roster: latestExport,
+        players: Array.from(roster.values()),
+        count: roster.size,
+      });
+      return;
+    }
+
+    if (message.type === "fc26:copyRoster") {
+      (async () => {
+        try {
+          if (!latestExport) {
+            throw new Error("No club data captured yet");
+          }
+          await navigator.clipboard.writeText(latestExport);
+          sendResponse({ success: true });
+        } catch (error) {
+          sendResponse({ success: false, error: error.message || String(error) });
+        }
+      })();
+      return true;
+    }
+
+    if (message.type === "fc26:clearRoster") {
+      roster.clear();
+      latestExport = "";
+      sendResponse({ success: true });
+      return;
+    }
+
+    return false;
+  }
+
+  if (typeof chrome !== "undefined" && chrome.runtime?.onMessage) {
+    chrome.runtime.onMessage.addListener(handleMessage);
+  }
+})();

--- a/public/tools/club-import-tool/manifest.json
+++ b/public/tools/club-import-tool/manifest.json
@@ -1,17 +1,30 @@
 {
   "manifest_version": 3,
-  "name": "My First Extension",
-  "description": "Clicks a button, does a thing.",
-  "version": "1.0.0",
+  "name": "FC 26 Club Import Tool",
+  "description": "Capture your EA FC 26 club roster and export it for import workflows.",
+  "version": "0.1.0",
   "action": {
-    "default_title": "My First Extension",
+    "default_title": "FC 26 Club Import Tool",
     "default_popup": "popup.html"
   },
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["activeTab", "scripting"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": ["activeTab", "tabs", "contextMenus"],
+  "host_permissions": [
+    "https://ea.com/*",
+    "https://*.ea.com/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "https://ea.com/*",
+        "https://*.ea.com/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/public/tools/club-import-tool/popup.html
+++ b/public/tools/club-import-tool/popup.html
@@ -2,15 +2,234 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Popup</title>
+    <title>FC 26 Club Import Tool</title>
     <style>
-      body { font: 14px system-ui; padding: 12px; width: 220px; }
-      button { padding: 8px 10px; border: 1px solid #ddd; border-radius: 8px; cursor: pointer; }
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        padding: 16px;
+        width: 360px;
+        background: linear-gradient(180deg, #0f172a 0%, #111827 35%, #0b1120 100%);
+        color: #e2e8f0;
+        box-sizing: border-box;
+      }
+
+      h1,
+      h2,
+      p {
+        margin: 0;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+
+      .header img {
+        width: 40px;
+        height: 40px;
+      }
+
+      .header h1 {
+        font-size: 18px;
+        font-weight: 600;
+      }
+
+      .header p {
+        font-size: 12px;
+        color: rgba(226, 232, 240, 0.75);
+      }
+
+      .card {
+        background: rgba(15, 23, 42, 0.75);
+        border: 1px solid rgba(148, 163, 184, 0.15);
+        border-radius: 16px;
+        padding: 16px;
+        margin-bottom: 12px;
+        box-shadow: 0 20px 35px rgba(15, 23, 42, 0.25);
+        backdrop-filter: blur(12px);
+      }
+
+      .status {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 12px;
+        font-size: 14px;
+      }
+
+      .status-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 9999px;
+        background: #f97316;
+        box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.25);
+      }
+
+      .status-dot.ready {
+        background: #22c55e;
+        box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.25);
+      }
+
+      .status-message {
+        flex: 1;
+      }
+
+      .actions {
+        display: flex;
+        gap: 8px;
+      }
+
+      button {
+        appearance: none;
+        border: none;
+        border-radius: 9999px;
+        font-size: 13px;
+        font-weight: 600;
+        padding: 10px 14px;
+        cursor: pointer;
+        transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+      }
+
+      button.primary {
+        background: linear-gradient(135deg, #2563eb, #7c3aed);
+        color: white;
+        box-shadow: 0 12px 25px rgba(79, 70, 229, 0.35);
+      }
+
+      button.ghost {
+        background: transparent;
+        color: rgba(226, 232, 240, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+      }
+
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+
+      button:not(:disabled):hover {
+        transform: translateY(-1px);
+        box-shadow: 0 18px 32px rgba(79, 70, 229, 0.45);
+      }
+
+      .instructions {
+        list-style: decimal;
+        padding-left: 18px;
+        margin: 12px 0 0;
+        color: rgba(226, 232, 240, 0.8);
+        font-size: 12px;
+        display: grid;
+        gap: 6px;
+      }
+
+      .player-count {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+        font-size: 13px;
+        color: rgba(226, 232, 240, 0.75);
+      }
+
+      .player-list {
+        max-height: 200px;
+        overflow-y: auto;
+        display: grid;
+        gap: 10px;
+        padding-right: 4px;
+      }
+
+      .player-row {
+        display: grid;
+        grid-template-columns: auto;
+        gap: 4px;
+        padding: 10px 12px;
+        border-radius: 12px;
+        background: rgba(30, 41, 59, 0.7);
+        border: 1px solid rgba(148, 163, 184, 0.12);
+      }
+
+      .player-name {
+        font-weight: 600;
+        font-size: 14px;
+      }
+
+      .player-meta,
+      .player-positions {
+        font-size: 12px;
+        color: rgba(226, 232, 240, 0.65);
+      }
+
+      .empty-state {
+        text-align: center;
+        font-size: 13px;
+        color: rgba(226, 232, 240, 0.6);
+        padding: 16px 8px;
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        border-radius: 9999px;
+        font-size: 12px;
+        background: rgba(37, 99, 235, 0.2);
+        color: rgba(191, 219, 254, 0.9);
+      }
     </style>
   </head>
   <body>
-    <h3>Hello, Page!</h3>
-    <button id="paint">Paint background</button>
+    <header class="header">
+      <img src="icons/icon48.png" alt="FC 26 badge" />
+      <div>
+        <h1>FC 26 Club Import Tool</h1>
+        <p>Capture your club roster from the EA FC web app.</p>
+      </div>
+    </header>
+
+    <section class="card">
+      <div class="status">
+        <span class="status-dot" id="status-dot"></span>
+        <div class="status-message" id="status-message">Waiting for an EA FC tab…</div>
+      </div>
+      <div class="actions">
+        <button id="copy-roster" class="primary" disabled>Copy roster export</button>
+        <button id="clear-roster" class="ghost" disabled>Clear</button>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="player-count">
+        <span>Captured players</span>
+        <span class="pill"><strong id="player-count">0</strong> tracked</span>
+      </div>
+      <div class="player-list" id="player-list">
+        <div class="empty-state" id="empty-state">
+          Browse your Ultimate Team club in the EA FC 26 web app to start capturing players.
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2 style="font-size: 13px; font-weight: 600; margin-bottom: 8px;">How to use</h2>
+      <ol class="instructions">
+        <li>Open <strong>https://www.ea.com</strong> and launch the EA FC 26 web app.</li>
+        <li>Navigate to your Club and browse the squads or piles you want to capture.</li>
+        <li>Keep this popup open or click the toolbar icon to refresh the captured list.</li>
+        <li>Hit <em>Copy roster export</em> to send the formatted list to your clipboard.</li>
+      </ol>
+    </section>
+
     <script src="popup.js"></script>
   </body>
 </html>

--- a/public/tools/club-import-tool/popup.js
+++ b/public/tools/club-import-tool/popup.js
@@ -1,14 +1,187 @@
-document.getElementById('paint').addEventListener('click', async () => {
+const statusDot = document.getElementById("status-dot");
+const statusMessage = document.getElementById("status-message");
+const copyButton = document.getElementById("copy-roster");
+const clearButton = document.getElementById("clear-roster");
+const playerCount = document.getElementById("player-count");
+const playerList = document.getElementById("player-list");
+const emptyState = document.getElementById("empty-state");
+
+let activeTabId = null;
+
+async function init() {
+  const tab = await getActiveTab();
+  if (!tab?.id) {
+    setStatus("No active tab found. Open the EA FC web app and try again.");
+    toggleReady(false);
+    return;
+  }
+
+  activeTabId = tab.id;
+  copyButton.addEventListener("click", handleCopy);
+  clearButton.addEventListener("click", handleClear);
+
+  await refreshSummary();
+}
+
+async function getActiveTab() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  await chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    func: () => {
-      // This runs in the page
-      const color = '#'+Math.floor(Math.random()*0xFFFFFF).toString(16).padStart(6,'0');
-      document.documentElement.style.transition = 'background 150ms ease';
-      document.documentElement.style.background = color;
-      console.log('Painted page with', color);
+  return tab;
+}
+
+async function refreshSummary() {
+  if (!activeTabId) return;
+
+  const response = await sendMessage(activeTabId, { type: "fc26:getSummary" });
+
+  if (!response?.success) {
+    toggleReady(false);
+    if (response?.error === "NO_CONTEXT") {
+      setStatus("Open the EA FC 26 web app and browse your club to start capturing.");
+    } else {
+      setStatus("Unable to connect to the EA FC page. Make sure it's open and refreshed.");
     }
+    renderPlayers([]);
+    return;
+  }
+
+  toggleReady(true);
+
+  if (response.count > 0) {
+    setStatus(`Capturing players from this tab. ${response.count} tracked so far.`);
+  } else {
+    setStatus("Connected. Browse your club to capture player data.");
+  }
+
+  renderPlayers(response.players || []);
+}
+
+async function handleCopy() {
+  if (!activeTabId) return;
+  setBusy(copyButton, true);
+  const response = await sendMessage(activeTabId, { type: "fc26:copyRoster" });
+  setBusy(copyButton, false);
+
+  if (response?.success) {
+    setStatus("Copied club export to clipboard.", true);
+  } else {
+    setStatus(response?.error || "Copy failed. Check the EA FC tab and try again.");
+  }
+}
+
+async function handleClear() {
+  if (!activeTabId) return;
+  setBusy(clearButton, true);
+  await sendMessage(activeTabId, { type: "fc26:clearRoster" });
+  setBusy(clearButton, false);
+  setStatus("Cleared captured players.");
+  await refreshSummary();
+}
+
+async function sendMessage(tabId, message) {
+  return new Promise((resolve) => {
+    chrome.tabs.sendMessage(tabId, message, (response) => {
+      if (chrome.runtime.lastError) {
+        resolve({ success: false, error: "NO_CONTEXT" });
+        return;
+      }
+      resolve(response);
+    });
   });
-  window.close();
+}
+
+function renderPlayers(players) {
+  const sorted = [...players].sort((a, b) => b.rating - a.rating);
+  const top = sorted.slice(0, 12);
+
+  playerList.innerHTML = "";
+
+  if (!top.length) {
+    emptyState.style.display = "block";
+    playerList.appendChild(emptyState);
+    playerCount.textContent = "0";
+    copyButton.disabled = true;
+    clearButton.disabled = true;
+    return;
+  }
+
+  emptyState.style.display = "none";
+  playerCount.textContent = String(players.length);
+  copyButton.disabled = false;
+  clearButton.disabled = false;
+
+  for (const player of top) {
+    const row = document.createElement("div");
+    row.className = "player-row";
+
+    const name = document.createElement("div");
+    name.className = "player-name";
+    name.textContent = `${player.name} (${player.rating})`;
+
+    const meta = document.createElement("div");
+    meta.className = "player-meta";
+    meta.textContent = [player.club, player.league, player.nation]
+      .map((part) => part?.trim())
+      .filter(Boolean)
+      .join(" • ");
+
+    const positions = document.createElement("div");
+    positions.className = "player-positions";
+    positions.textContent = player.positions?.length
+      ? `Positions: ${player.positions.join(", ")}`
+      : "";
+
+    row.appendChild(name);
+    if (meta.textContent) {
+      row.appendChild(meta);
+    }
+    if (positions.textContent) {
+      row.appendChild(positions);
+    }
+
+    playerList.appendChild(row);
+  }
+
+  if (players.length > top.length) {
+    const more = document.createElement("div");
+    more.className = "player-meta";
+    more.style.textAlign = "center";
+    more.textContent = `…and ${players.length - top.length} more players captured.`;
+    playerList.appendChild(more);
+  }
+}
+
+function setStatus(message, highlight = false) {
+  statusMessage.textContent = message;
+  if (highlight) {
+    statusMessage.style.color = "#a5f3fc";
+  } else {
+    statusMessage.style.color = "inherit";
+  }
+}
+
+function toggleReady(ready) {
+  if (ready) {
+    statusDot.classList.add("ready");
+  } else {
+    statusDot.classList.remove("ready");
+  }
+}
+
+function setBusy(button, busy) {
+  if (busy) {
+    button.disabled = true;
+    button.dataset.originalText = button.textContent;
+    button.textContent = "Working…";
+  } else {
+    button.textContent = button.dataset.originalText || button.textContent;
+    button.disabled = false;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  init().catch((error) => {
+    console.error("Failed to initialise popup", error);
+    setStatus("Unexpected error while initialising extension.");
+    toggleReady(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add a production-ready manifest that injects the club capture content script on EA domains and exposes a context menu
- port the club export harvesting logic into a reusable content script that powers the popup and the in-page overlay
- redesign the popup UI to show capture status, player previews, and clipboard/clear actions backed by messaging helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd93986568832189c7f850ffd4d002