### PR TITLE
Add AK Tools logo assets for favicon and header

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>AK Tools</title>
   </head>
   <body>

--- a/public/ak-tools-logo.svg
+++ b/public/ak-tools-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img">
+  <rect width="256" height="256" fill="#f7f9fc" rx="56" />
+  <g fill="#0f2740">
+    <text x="44" y="132" font-family="'Montserrat', 'Avenir Next', sans-serif" font-weight="700" font-size="72" letter-spacing="4">AK</text>
+    <path d="M172 76a38 38 0 0 0-36.94 30.65 12 12 0 0 1-3.32 6.24l-52.8 52.8 13.66 13.66 52.8-52.8a12 12 0 0 1 6.24-3.32A38 38 0 1 0 196 76a10 10 0 0 1-12 12 10 10 0 0 1-10-10 12 12 0 0 0-12-12Z"/>
+  </g>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <rect width="64" height="64" fill="#f7f9fc" rx="12" />
+  <g fill="#0f2740">
+    <text x="8" y="36" font-family="'Montserrat', 'Avenir Next', sans-serif" font-weight="700" font-size="22" letter-spacing="2">AK</text>
+    <path d="M43 20a11 11 0 0 0-10.66 8.88 3.4 3.4 0 0 1-.96 1.72l-14.2 14.2 3.68 3.68 14.2-14.2a3.4 3.4 0 0 1 1.72-.96A11 11 0 1 0 49 20a2.8 2.8 0 0 1-3.4 3.4 2.8 2.8 0 0 1-2.8-2.8 3.8 3.8 0 0 0-3.8-3.8Z"/>
+  </g>
+</svg>

--- a/src/app/layouts/root-layout.tsx
+++ b/src/app/layouts/root-layout.tsx
@@ -59,9 +59,14 @@ export default function RootLayout() {
             <div className="flex items-center justify-between gap-3">
               <Link
                 to="/"
-                className="inline-flex items-center rounded-brand-full border border-transparent bg-white/80 px-6 py-3 text-sm font-semibold tracking-[0.26em] text-brand-strong shadow-brand-sm transition-all duration-300 hover:-translate-y-0.5 hover:text-brand-strong/80 dark:bg-surface-overlayDark/80 dark:text-white"
+                className="inline-flex items-center rounded-brand-full border border-transparent bg-white/80 px-4 py-3 text-sm font-semibold tracking-[0.26em] text-brand-strong shadow-brand-sm transition-all duration-300 hover:-translate-y-0.5 hover:text-brand-strong/80 dark:bg-surface-overlayDark/80 dark:text-white"
               >
-                AK TOOLS
+                <img
+                  src="/ak-tools-logo.svg"
+                  alt="AK Tools logo"
+                  className="h-10 w-auto"
+                  loading="lazy"
+                />
               </Link>
               <AuthControls
                 user={user}


### PR DESCRIPTION
## Summary
- add AK Tools logo SVG assets for the site header and favicon
- update the root layout to display the logo image in the top-left navigation link
- register the new favicon in the document head

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d080c734c083219bbb7ed424c04cc6