### PR TITLE
Adjust stat pill styling for dark mode

### DIFF
--- a/src/pages/pickup/pickup-page.tsx
+++ b/src/pages/pickup/pickup-page.tsx
@@ -276,14 +276,14 @@ function GameCard({ game, user }: { game: Game; user: User | null }) {
           <div>
             <h3 className="text-lg font-semibold text-brand-strong dark:text-white">{game.title}</h3>
             <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-brand-muted dark:text-brand-subtle">
-              <span className="inline-flex items-center gap-1 rounded-brand-full bg-surface/70 px-3 py-1">
+              <span className="inline-flex items-center gap-1 rounded-brand-full border border-border-light/60 bg-surface/80 px-3 py-1 text-brand-strong shadow-brand-sm dark:border-border-dark/60 dark:bg-surface-overlayDark/80 dark:text-white">
                 📍 {game.fieldName}
               </span>
-              <span className="inline-flex items-center gap-1 rounded-brand-full bg-surface/70 px-3 py-1">
+              <span className="inline-flex items-center gap-1 rounded-brand-full border border-border-light/60 bg-surface/80 px-3 py-1 text-brand-strong shadow-brand-sm dark:border-border-dark/60 dark:bg-surface-overlayDark/80 dark:text-white">
                 🕒 {dateStr}
               </span>
               {user?.uid === game.organizerUid && (
-                <span className="inline-flex items-center gap-1 rounded-brand-full bg-brand/15 px-3 py-1 text-brand">
+                <span className="inline-flex items-center gap-1 rounded-brand-full border border-brand/30 bg-brand/15 px-3 py-1 text-brand shadow-brand-sm dark:border-brand/50 dark:bg-brand/30 dark:text-brand-foreground">
                   👑 Organizer
                 </span>
               )}

--- a/src/pages/pickup/pickup-page.tsx
+++ b/src/pages/pickup/pickup-page.tsx
@@ -290,7 +290,9 @@ function GameCard({ game, user }: { game: Game; user: User | null }) {
             </div>
           </div>
           <div className="text-right text-sm">
-            <div className="font-semibold text-brand">{goingCount}</div>
+            <div className="font-semibold text-brand dark:text-brand-foreground">
+              {goingCount}
+            </div>
             <div className="text-xs uppercase tracking-[0.18em] text-brand-muted dark:text-brand-subtle">of {game.maxPlayers} spots</div>
             <div className="mt-1 text-xs text-brand-subtle">
               {full ? "Roster full" : `${spotsLeft} spots left`}

--- a/src/shared/components/page.tsx
+++ b/src/shared/components/page.tsx
@@ -150,7 +150,7 @@ export function PageSection({
 // Capsule-shaped badge for highlighting quick stats.
 export function StatPill({ children }: { children: ReactNode }) {
   return (
-    <span className="inline-flex items-center gap-2 rounded-brand-full border border-brand/20 bg-brand/5 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-brand-strong/80 shadow-brand-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/10 dark:text-white/80">
+    <span className="inline-flex items-center gap-2 rounded-brand-full border border-brand/20 bg-brand/5 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-brand-strong/80 shadow-brand-sm backdrop-blur-sm dark:border-brand/40 dark:bg-brand/20 dark:text-white">
       {children}
     </span>
   );


### PR DESCRIPTION
## Summary
- update StatPill dark-mode colors to use branded border, background, and white text for better contrast on the Pickup game page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d08177da7c832197d37c43fbd366cf