### PR TITLE
Send project form submissions via EmailJS

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,5 +9,10 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_PROJECT_ID: string;
   readonly VITE_FIREBASE_STORAGE_BUCKET: string;
   readonly VITE_FIREBASE_APP_ID: string;
+  readonly VITE_EMAILJS_SERVICE_ID?: string;
+  readonly VITE_EMAILJS_TEMPLATE_ID?: string;
+  readonly VITE_EMAILJS_PUBLIC_KEY?: string;
 }
-interface ImportMeta { readonly env: ImportMetaEnv; }
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- send the project brief form via the EmailJS REST endpoint using the provided service id
- add submission status handling to give sending and error feedback on the form
- expose the EmailJS environment variables through the Vite env typings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0bb1d1efc8321be89ad9625cab508