### PR TITLE
Improve mobile navigation and rebrand Tools area to Apps

### DIFF
--- a/src/app/layouts/root-layout.tsx
+++ b/src/app/layouts/root-layout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
-import { Github, Instagram, Linkedin } from "lucide-react";
+import { Github, Instagram, Linkedin, Menu, X } from "lucide-react";
 import { onAuthStateChanged, signInWithPopup, signOut, type User } from "firebase/auth";
 
 import { ThemeToggle } from "../../shared/components/theme-toggle";
@@ -27,16 +27,20 @@ function GoogleG({ className = "h-4 w-4" }: { className?: string }) {
 // Shared page chrome with authentication controls and footer links.
 export default function RootLayout() {
   const [user, setUser] = useState<User | null>(null);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const location = useLocation();
 
   const navItems = [
     { id: "home", label: "Amer", to: "/" },
-    { id: "tools", label: "Tools", to: "/tools" },
+    { id: "apps", label: "Apps", to: "/tools" },
     { id: "professional", label: "Professional", to: "/professional" },
   ] as const;
 
   // Keep layout state aligned with Firebase auth changes.
   useEffect(() => onAuthStateChanged(auth, setUser), []);
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [location.pathname]);
 
   const handleSignIn = async () => {
     await signInWithPopup(auth, googleProvider);
@@ -62,40 +66,72 @@ export default function RootLayout() {
               background: "rgba(56,189,248,0.14)",
             }}
           />
-          <div className="relative flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
-            <nav className="flex flex-wrap items-center gap-3 text-sm">
-              {navItems.map((item) => {
-                const active =
-                  item.to === "/"
-                    ? location.pathname === "/"
-                    : location.pathname.startsWith(item.to);
-                return (
-                  <Link
-                    key={item.id}
-                    to={item.to}
-                    className={cn(
-                      "inline-flex items-center gap-2 rounded-full border px-4 py-2 font-medium uppercase tracking-[0.24em] transition-all duration-200",
-                      active
-                        ? "border-brand bg-brand/15 text-brand shadow-brand-sm dark:border-brand/60 dark:bg-brand/25 dark:text-brand-foreground"
-                        : "border-border-light/70 bg-white/70 text-brand-muted shadow-none hover:-translate-y-0.5 hover:shadow-brand dark:border-border-dark/60 dark:bg-white/10 dark:text-brand-subtle"
-                    )}
-                  >
-                    <span>{item.label}</span>
-                    {active ? (
-                      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand text-white text-[0.6rem] shadow-brand-sm dark:bg-brand-strong">
-                        ●
-                      </span>
-                    ) : null}
-                  </Link>
-                );
-              })}
-            </nav>
-            <AuthControls
-              user={user}
-              onSignIn={handleSignIn}
-              onSignOut={handleSignOut}
-              className="flex w-full justify-end md:ml-auto md:w-auto"
-            />
+          <div className="relative flex flex-col gap-5">
+            <div className="flex items-center justify-between md:hidden">
+              <button
+                type="button"
+                onClick={() => setMobileNavOpen((open) => !open)}
+                aria-controls="primary-navigation"
+                aria-expanded={mobileNavOpen}
+                className="inline-flex items-center gap-2 rounded-full border border-border-light/70 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-brand-strong shadow-brand-sm transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand dark:border-border-dark/60 dark:bg-white/10 dark:text-brand-foreground"
+              >
+                {mobileNavOpen ? (
+                  <X className="h-4 w-4" aria-hidden />
+                ) : (
+                  <Menu className="h-4 w-4" aria-hidden />
+                )}
+                <span>Menu</span>
+              </button>
+              <AuthControls
+                user={user}
+                onSignIn={handleSignIn}
+                onSignOut={handleSignOut}
+                className="md:hidden"
+              />
+            </div>
+            <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+              <nav
+                id="primary-navigation"
+                className={cn(
+                  "grid gap-3 text-sm md:flex md:flex-wrap md:items-center",
+                  "mt-4 md:mt-0",
+                  mobileNavOpen ? "grid" : "hidden md:flex"
+                )}
+              >
+                {navItems.map((item) => {
+                  const active =
+                    item.to === "/"
+                      ? location.pathname === "/"
+                      : location.pathname.startsWith(item.to);
+                  return (
+                    <Link
+                      key={item.id}
+                      to={item.to}
+                      className={cn(
+                        "inline-flex items-center gap-2 rounded-full border px-4 py-2 font-medium uppercase tracking-[0.24em] transition-all duration-200",
+                        "w-full justify-between text-sm md:w-auto md:justify-start",
+                        active
+                          ? "border-brand bg-brand/15 text-brand shadow-brand-sm dark:border-brand/60 dark:bg-brand/25 dark:text-brand-foreground"
+                          : "border-border-light/70 bg-white/70 text-brand-muted shadow-none hover:-translate-y-0.5 hover:shadow-brand dark:border-border-dark/60 dark:bg-white/10 dark:text-brand-subtle"
+                      )}
+                    >
+                      <span>{item.label}</span>
+                      {active ? (
+                        <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand text-white text-[0.6rem] shadow-brand-sm dark:bg-brand-strong">
+                          ●
+                        </span>
+                      ) : null}
+                    </Link>
+                  );
+                })}
+              </nav>
+              <AuthControls
+                user={user}
+                onSignIn={handleSignIn}
+                onSignOut={handleSignOut}
+                className="hidden w-full justify-end md:ml-auto md:flex md:w-auto"
+              />
+            </div>
           </div>
         </div>
       </header>

--- a/src/app/router/routes.tsx
+++ b/src/app/router/routes.tsx
@@ -14,7 +14,7 @@ import {
   PickupPage,
   SecretSantaPage,
   UltimateTeamPage,
-  ToolsLandingPage,
+  AppsLandingPage,
 } from "../../pages";
 
 // Application routes wire feature pages into the shared RootLayout shell.
@@ -27,7 +27,7 @@ export const routes: RouteObject[] = [
       {
         path: "tools",
         children: [
-          { index: true, element: <ToolsLandingPage /> },
+          { index: true, element: <AppsLandingPage /> },
           { path: "pickup", element: <PickupPage /> },
           { path: "pickup/:gameId", element: <PickupGamePage /> },
           { path: "new", element: <CreateGamePage /> },

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -4,27 +4,18 @@ import { Link } from "react-router-dom";
 import { PageHero, PageSection } from "../../shared/components/page";
 import {
   PROFESSIONAL_LINKS,
-  TOOL_LINKS,
+  APP_LINKS,
   type SiteLink,
 } from "../../shared/data/site-map";
 
 const GROUPS: {
-  id: "tools" | "professional";
+  id: "apps" | "professional";
   title: string;
   description: string;
   cta: string;
   to: string;
   items: SiteLink[];
 }[] = [
-  {
-    id: "tools",
-    title: "Tools & automations for everyday moments",
-    description:
-      "Play organizers, friend groups, and communities use these utilities to stay coordinated without spinning up custom apps.",
-    cta: "Explore tools",
-    to: "/tools",
-    items: TOOL_LINKS,
-  },
   {
     id: "professional",
     title: "Professional work & ways to collaborate",
@@ -34,6 +25,15 @@ const GROUPS: {
     to: "/professional",
     items: PROFESSIONAL_LINKS,
   },
+  {
+    id: "apps",
+    title: "Apps & automations for everyday moments",
+    description:
+      "Play organizers, friend groups, and communities use these utilities to stay coordinated without spinning up custom builds.",
+    cta: "Explore apps",
+    to: "/tools",
+    items: APP_LINKS,
+  },
 ];
 
 export default function HomePage() {
@@ -42,7 +42,7 @@ export default function HomePage() {
       <PageHero
         align="center"
         title="Welcome to Amer Kovačević’s digital workspace"
-        description="Choose a path below so dedicated tools live alongside the professional studio and you can get to the right experience fast."
+        description="Choose a path below so dedicated apps live alongside the professional studio and you can get to the right experience fast."
         actions={
           <div className="flex flex-wrap justify-center gap-3">
             {GROUPS.map((group) => (

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,6 +1,6 @@
 // Central export hub so routes can import every page from a single module.
 export { default as HomePage } from "./home/home-page";
-export { default as ToolsLandingPage } from "./tools/tools-landing-page";
+export { default as AppsLandingPage } from "./tools/tools-landing-page";
 export { default as ProfessionalLandingPage } from "./professional/professional-landing-page";
 export { default as PickupPage } from "./pickup/pickup-page";
 export { default as PickupGamePage } from "./pickup/pickup-game-page";

--- a/src/pages/professional/professional-landing-page.tsx
+++ b/src/pages/professional/professional-landing-page.tsx
@@ -12,17 +12,17 @@ export default function ProfessionalLandingPage() {
         title="Explore the professional studio"
         description="Review portfolio work, open the contact directory, or kick off a scoped engagement when you are ready to collaborate."
         actions={
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
             <Link
               to="/professional/start-a-project"
-              className="inline-flex items-center gap-2 rounded-full bg-brand px-6 py-3 text-xs font-semibold uppercase tracking-[0.28em] text-white shadow-brand-sm transition-transform duration-300 hover:-translate-y-0.5 hover:shadow-brand"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-brand px-6 py-3 text-xs font-semibold uppercase tracking-[0.28em] text-white shadow-brand-sm transition-transform duration-300 hover:-translate-y-0.5 hover:shadow-brand sm:w-auto"
             >
               Start a project
               <ArrowUpRight className="h-4 w-4" aria-hidden />
             </Link>
             <Link
               to="/professional/links"
-              className="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.28em] text-brand-strong shadow-brand-sm transition-transform duration-300 hover:-translate-y-0.5 hover:shadow-brand dark:border-white/20 dark:bg-white/10 dark:text-brand-foreground"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/50 bg-white/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.28em] text-brand-strong shadow-brand-sm transition-transform duration-300 hover:-translate-y-0.5 hover:shadow-brand dark:border-white/20 dark:bg-white/10 dark:text-brand-foreground sm:w-auto"
             >
               View contact hub
               <ArrowUpRight className="h-4 w-4" aria-hidden />

--- a/src/pages/tools/tools-landing-page.tsx
+++ b/src/pages/tools/tools-landing-page.tsx
@@ -2,14 +2,14 @@ import { ArrowUpRight } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { PageHero, PageSection } from "../../shared/components/page";
-import { TOOL_LINKS, type SiteLink } from "../../shared/data/site-map";
+import { APP_LINKS, type SiteLink } from "../../shared/data/site-map";
 
-export default function ToolsLandingPage() {
+export default function AppsLandingPage() {
   return (
     <div className="space-y-10">
       <PageHero
-        icon="🛠️"
-        title="Choose a tool and get right to work"
+        icon="📱"
+        title="Choose an app and get right to work"
         description="Utilities for pickup sports, holiday exchanges, bracket planning, and FIFA make it easy to spin up gatherings without spreadsheets."
         actions={
           <Link
@@ -23,18 +23,18 @@ export default function ToolsLandingPage() {
       />
 
       <PageSection contentClassName="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
-        {TOOL_LINKS.map((tool) => (
-          <ToolCard key={tool.id} tool={tool} />
+        {APP_LINKS.map((app) => (
+          <AppCard key={app.id} app={app} />
         ))}
       </PageSection>
     </div>
   );
 }
 
-function ToolCard({ tool }: { tool: SiteLink }) {
+function AppCard({ app }: { app: SiteLink }) {
   return (
     <Link
-      to={tool.to}
+      to={app.to}
       className="group relative flex h-full flex-col justify-between overflow-hidden rounded-brand-lg border border-border-light bg-surface p-6 text-left text-brand-strong shadow-brand-sm transition duration-300 hover:-translate-y-1 hover:border-brand/40 hover:shadow-brand dark:border-border-dark dark:bg-surface-muted dark:text-brand-foreground"
     >
       <div
@@ -43,16 +43,16 @@ function ToolCard({ tool }: { tool: SiteLink }) {
       />
       <div className="relative flex items-start justify-between">
         <span className="relative grid h-14 w-14 place-items-center rounded-[1.35rem] bg-gradient-to-br from-white via-white/60 to-white/20 text-3xl shadow-brand-sm ring-1 ring-border-light transition-colors duration-300 dark:from-slate-900 dark:via-slate-900/60 dark:to-slate-900/40 dark:ring-border-dark">
-          <span aria-hidden>{tool.emoji}</span>
-          <span className="sr-only">{tool.name} icon</span>
+          <span aria-hidden>{app.emoji}</span>
+          <span className="sr-only">{app.name} icon</span>
         </span>
         <span className="mt-1 text-brand-muted transition-transform duration-300 group-hover:-translate-y-1 group-hover:translate-x-1 dark:text-brand-subtle">
           <ArrowUpRight className="h-5 w-5" aria-hidden />
         </span>
       </div>
       <div className="relative mt-4 space-y-3">
-        <h3 className="text-lg font-semibold text-brand-strong dark:text-brand-foreground">{tool.name}</h3>
-        <p className="text-sm text-brand-muted dark:text-brand-subtle">{tool.blurb}</p>
+        <h3 className="text-lg font-semibold text-brand-strong dark:text-brand-foreground">{app.name}</h3>
+        <p className="text-sm text-brand-muted dark:text-brand-subtle">{app.blurb}</p>
       </div>
     </Link>
   );

--- a/src/pages/ultimate-team/ultimate-team-page.tsx
+++ b/src/pages/ultimate-team/ultimate-team-page.tsx
@@ -10,7 +10,7 @@ const PIPELINE_STEPS = [
   },
   {
     title: "Instant availability",
-    description: "The processed club sheet unlocks the rest of the tools without needing manual copy and paste gymnastics.",
+    description: "The processed club sheet unlocks the rest of the apps without needing manual copy and paste gymnastics.",
   },
 ];
 
@@ -38,12 +38,12 @@ export default function UltimateTeamPage() {
       <PageHero
         align="center"
         title="Ultimate Team Utility"
-        description="Tools to simplify Ultimate Team management and squad building."
+        description="Apps to simplify Ultimate Team management and squad building."
       />
 
       <PageSection
         title="Club import"
-        description="Automated processing is nearly ready, so drop your export and we'll prep it for the full toolkit."
+        description="Automated processing is nearly ready, so drop your export and we'll prep it for the full app suite."
         contentClassName="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]"
       >
         <div className="space-y-6">
@@ -104,7 +104,7 @@ export default function UltimateTeamPage() {
         </aside>
       </PageSection>
 
-      <PageSection title="Coming soon" description="These helpers round out the toolkit next.">
+      <PageSection title="Coming soon" description="These helpers round out the app suite next.">
         <div className="grid gap-5 lg:grid-cols-3">
           {FEATURES.map((feature) => (
             <article

--- a/src/shared/data/site-map.ts
+++ b/src/shared/data/site-map.ts
@@ -6,7 +6,7 @@ export type SiteLink = {
   emoji: string;
 };
 
-export const TOOL_LINKS: SiteLink[] = [
+export const APP_LINKS: SiteLink[] = [
   {
     id: "pickup",
     name: "Pickup Soccer",
@@ -68,4 +68,4 @@ export const PROFESSIONAL_LINKS: SiteLink[] = [
   },
 ];
 
-export const ALL_LINKS: SiteLink[] = [...TOOL_LINKS, ...PROFESSIONAL_LINKS];
+export const ALL_LINKS: SiteLink[] = [...APP_LINKS, ...PROFESSIONAL_LINKS];


### PR DESCRIPTION
## Summary
- add a collapsible mobile navigation toggle and updated branding for the Apps tab in the shared layout
- reorder the Amer home page highlights so the professional hub appears first and update copy throughout to refer to Apps
- refresh the Apps landing page, professional call-to-actions, and Ultimate Team copy to match the new branding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1d36dbca0832184d4cea174e2c6c8