### PR TITLE
Add Google Analytics initialization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
 VITE_FIREBASE_APP_ID=your-app-id
+VITE_GA_MEASUREMENT_ID=your-ga-measurement-id

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,14 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./shared/styles/globals.css";
 
+import { initializeAnalytics } from "./shared/lib/analytics";
+
 import { AppRouter, ThemeProvider } from "./app";
 
 // Hydrate the single-page app, wrapping every route in the theme context so
 // dark/light mode stays in sync across navigation.
+initializeAnalytics();
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider>

--- a/src/shared/lib/analytics.ts
+++ b/src/shared/lib/analytics.ts
@@ -1,0 +1,52 @@
+const measurementId = import.meta.env.VITE_GA_MEASUREMENT_ID;
+
+// Inject the Google Analytics script into the document head and set up the gtag
+// helper only in production builds when a measurement id is provided.
+export const initializeAnalytics = () => {
+  if (!measurementId) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        "VITE_GA_MEASUREMENT_ID is not configured – skipping Google Analytics setup."
+      );
+    }
+
+    return;
+  }
+
+  if (!import.meta.env.PROD) {
+    return;
+  }
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const existingScript = document.querySelector(
+    `script[src="https://www.googletagmanager.com/gtag/js?id=${measurementId}"]`
+  );
+
+  if (!existingScript) {
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
+    document.head.appendChild(script);
+  }
+
+  window.dataLayer = window.dataLayer ?? [];
+
+  function gtag(...args: unknown[]) {
+    window.dataLayer!.push(args);
+  }
+
+  window.gtag = gtag;
+
+  gtag("js", new Date());
+  gtag("config", measurementId);
+};
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared analytics helper that injects the Google Analytics tag during production builds
- initialize analytics when the React app boots and document the required measurement id environment variable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d20aeca4dc832188c33ca6f4fdb601